### PR TITLE
Adjust build step for our repo

### DIFF
--- a/.github/workflows/docker-stable-publish.yml
+++ b/.github/workflows/docker-stable-publish.yml
@@ -2,7 +2,8 @@ name: Publish Docker image
 
 on:
   push:
-    branches: ['main']
+    tags:
+      - 2**-**-**
 
 env:
   REGISTRY: ghcr.io
@@ -38,8 +39,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch,suffix=_{{sha}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=tag
+            type=raw,event=tag,value=stable
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v4


### PR DESCRIPTION
This PR adjusts the existing github action for publishing images to make it relevant to our repo.  It adjusts the existing workflow to only push to ghcr and building off our repo instead of piraces, and it adds a new workflow for publishing a new `stable` image whenever we push up a new tag(that matches the `yyyy-mm-dd` pattern).

With these workflows in place, we can more easily deploy and update rsslay on servers.